### PR TITLE
MANTA-1936 Rip out syslog logging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,6 @@
 [submodule "deps/manta-scripts"]
 	path = deps/manta-scripts
 	url = https://github.com/joyent/manta-scripts.git
-	branch = MANTA-1936
 [submodule "deps/eng"]
 	path = deps/eng
 	url = https://github.com/joyent/eng.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,7 @@
 [submodule "deps/manta-scripts"]
 	path = deps/manta-scripts
 	url = https://github.com/joyent/manta-scripts.git
+	branch = MANTA-1936
 [submodule "deps/eng"]
 	path = deps/eng
 	url = https://github.com/joyent/eng.git

--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ This repository is part of the Joyent Manta project.  For contribution
 guidelines, issues, and general documentation, visit the main
 [Manta](http://github.com/joyent/manta) project page.
 
-electric-boray is a Node-based service that provides data placement
-services. This includes services such as locating the correct physical storage
-location given the metadata for an object or providing the virtual nodes that
-belong to a physical storage node.
-
-
 # Building and running
 
 To run your own electric-boray from a copy of this repository, you'll want:
@@ -43,7 +37,7 @@ and run electric-boray with something like this:
         2>&1 | bunyan
 
 For example, if the configuration file and hash ring were copied to your
-electric-moray workspace, you'd use:
+electric-boray workspace, you'd use:
 
     $ node ./main.js -f ./config.json -r ./leveldb-2021 -p 2020 2>&1 | bunyan
 

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -203,6 +203,6 @@ manta_setup_electric_boray
 
 manta_buckets_setup_common_log_rotation "electric-boray"
 
-manta_common_setup_end
+manta_buckets_common_setup_end
 
 exit 0

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -191,7 +191,7 @@ manta_common_presetup
 echo "Adding local manifest directories"
 manta_add_manifest_dir "/opt/smartdc/electric-boray"
 
-manta_buckets_common_setup "electric-boray"
+manta_common2_setup "electric-boray"
 
 manta_setup_determine_instances
 
@@ -201,8 +201,8 @@ manta_setup_electric_boray_hash_ring
 echo "Setting up e-boray"
 manta_setup_electric_boray
 
-manta_buckets_setup_common_log_rotation "electric-boray"
+manta_common2_setup_log_rotation "electric-boray"
 
-manta_buckets_common_setup_end
+manta_common2_setup_end
 
 exit 0

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Copyright 2019, Joyent, Inc.
+# Copyright 2019 Joyent, Inc.
 #
 
 #
@@ -76,14 +76,6 @@ ZONE_UUID=$(/usr/bin/zonename)
 ZFS_PARENT_DATASET=zones/$ZONE_UUID/data
 ZFS_DATASET=$ZFS_PARENT_DATASET/electric-boray
 
-function manta_hack_syslog_conf {
-    # Hack.  See MANTA-2165
-    local conf=/etc/syslog.conf
-    if [[ -e $conf ]]; then
-        sed -ir 's/\/var\/log\/authlog/\/var\/log\/auth\.log/' $conf
-        sed -ir 's/\/var\/log\/maillog/\/var\/log\/postfix\.log/' $conf
-    fi
-}
 
 function manta_setup_determine_instances {
     ELECTRIC_BORAY_INSTANCES=1
@@ -191,73 +183,7 @@ function manta_setup_electric_boray {
     unset IFS
 }
 
-function manta_setup_boray_rsyslogd {
-    #rsyslog was already set up by common setup- this will overwrite the
-    # config and restart since we want boray to log locally.
-    local domain_name=$(json -f ${METADATA} domain_name)
-    [[ $? -eq 0 ]] || fatal "Unable to domain name from metadata"
-
-    mkdir -p /var/tmp/rsyslog/work
-    chmod 777 /var/tmp/rsyslog/work
-
-    cat > /etc/rsyslog.conf <<"HERE"
-$MaxMessageSize 64k
-
-$ModLoad immark
-$ModLoad imsolaris
-$ModLoad imudp
-
-
-$template bunyan,"%msg:R,ERE,1,FIELD:(\{.*\})--end%\n"
-
-*.err;kern.notice;auth.notice                   /dev/sysmsg
-*.err;kern.debug;daemon.notice;mail.crit        /var/adm/messages
-
-*.alert;kern.err;daemon.err                     operator
-*.alert                                         root
-
-*.emerg                                         *
-
-mail.debug                                      /var/log/syslog
-
-auth.info                                       /var/log/auth.log
-mail.info                                       /var/log/postfix.log
-
-$WorkDirectory /var/tmp/rsyslog/work
-$ActionQueueType LinkedList
-$ActionQueueFileName mantafwd
-$ActionResumeRetryCount -1
-$ActionQueueSaveOnShutdown on
-
-HERE
-
-        cat >> /etc/rsyslog.conf <<HERE
-
-# Support node bunyan logs going to local0 and forwarding
-# only as logs are already captured via SMF
-# Uncomment the following line to get local logs via syslog
-local0.* /var/log/electric-boray.log;bunyan
-local0.* @@ops.$domain_name:10514
-
-HERE
-
-        cat >> /etc/rsyslog.conf <<"HERE"
-$UDPServerAddress 127.0.0.1
-$UDPServerRun 514
-
-HERE
-
-    svcadm restart system-log
-    [[ $? -eq 0 ]] || fatal "Unable to restart rsyslog"
-
-    #log pulling
-    manta_add_logadm_entry "electric-boray" "/var/log" "exact"
-}
-
 # Mainline
-
-echo "Modifying syslog.conf"
-manta_hack_syslog_conf
 
 echo "Running common setup scripts"
 manta_common_presetup
@@ -265,7 +191,7 @@ manta_common_presetup
 echo "Adding local manifest directories"
 manta_add_manifest_dir "/opt/smartdc/electric-boray"
 
-manta_common_setup "electric-boray" 0
+manta_buckets_common_setup "electric-boray"
 
 manta_setup_determine_instances
 
@@ -274,7 +200,8 @@ manta_setup_electric_boray_hash_ring
 
 echo "Setting up e-boray"
 manta_setup_electric_boray
-manta_setup_boray_rsyslogd
+
+manta_buckets_setup_common_log_rotation "electric-boray"
 
 manta_common_setup_end
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
         "assert-plus": "1.0.0",
         "bignum": "0.6.0",
         "bunyan": "0.22.1",
-        "bunyan-syslog": "0.2.2",
         "clone": "0.1.9",
         "dtrace-provider": "0.2.8",
         "fash": "2.5.0",

--- a/sapi_manifests/electric-boray/template
+++ b/sapi_manifests/electric-boray/template
@@ -1,10 +1,6 @@
 {
     "bunyan": {
-        "level": "info",
-        "syslog": {
-            "facility": "local0",
-            "type": "udp"
-        }
+        "level": "info"
     },
     "fast": {
         "client_crc_mode": 3,

--- a/smf/manifests/electric-boray.xml.in
+++ b/smf/manifests/electric-boray.xml.in
@@ -7,11 +7,11 @@
 -->
 
 <!--
-    Copyright (c) 2019, Joyent, Inc.
+    Copyright 2019 Joyent, Inc.
 -->
 
 <service_bundle type="manifest" name="-electric-boray">
-    <service name="smartdc/application/electric-boray" type="service" version="1">
+    <service name="manta/application/electric-boray" type="service" version="1">
 
         <dependency name="network"
             grouping="require_all"


### PR DESCRIPTION
This is part of the work described by RFD 142. It removes the use of syslog logging and instead relies on SMF logging for each instance of the service. The log rotation and upload changes are part of this related PR for the manta-scripts repo.

Currently, I have the manta-scripts submodule changed to track the corresponding topic branch in the manta-scripts repo, but merging that change to manta-scripts and updating the submodule commit accordingly will be done prior to merging this PR.
Testing

I have been testing this work by building images and deploying them in my lab system. I have verified that the `electric-boray` instances are logging to their respective SMF log files and that the log files are properly rotated and uploaded each hour.