### PR TITLE
MANTA-5219 Configure metricPorts in buckets API components by default

### DIFF
--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -167,6 +167,19 @@ function manta_setup_buckets_mdplacement {
             fatal "unable to start $buckets_mdplacement_instance"
     done
 
+    #
+    # We join the metric ports in a comma-separated list, then add this list as
+    # metricPorts mdata to allow scraping by cmon-agent.
+    #
+    # The metricPorts values are derived from the buckets-mdplacement service's
+    # "SIZE" SAPI metadata. We don't need to worry about keeping the metricPorts
+    # updated if this variable changes, because such a change does not affect
+    # already-provisioned zones. This is because electric-moray zones pull the
+    # "SIZE" variable from /var/tmp/metadata.json, which is only written once,
+    # when the zone is provisioned -- it is not managed by config-agent.
+    #
+    mdata-put metricPorts $(IFS=','; echo "${kangs[*]}")
+
     unset IFS
 }
 


### PR DESCRIPTION
Tested the change by reprovisioning a bucket-mdplacement instance in a lab environment to the image with this PR and confirming that `mdata-get metricPorts` return the correct values.